### PR TITLE
android embedding v2に対応

### DIFF
--- a/android/src/main/kotlin/com/example/mecab_dart/MecabDartPlugin.kt
+++ b/android/src/main/kotlin/com/example/mecab_dart/MecabDartPlugin.kt
@@ -6,30 +6,14 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 
 /** MecabDartPlugin */
 public class MecabDartPlugin: FlutterPlugin, MethodCallHandler {
-  override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-    val channel = MethodChannel(flutterPluginBinding.getFlutterEngine().getDartExecutor(), "mecab_dart")
-    channel.setMethodCallHandler(MecabDartPlugin());
-  }
+  private lateinit var channel: MethodChannel
 
-  // This static function is optional and equivalent to onAttachedToEngine. It supports the old
-  // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
-  // plugin registration via this function while apps migrate to use the new Android APIs
-  // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
-  //
-  // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
-  // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
-  // depending on the user's project. onAttachedToEngine or registerWith must both be defined
-  // in the same class.
-  companion object {
-    @JvmStatic
-    fun registerWith(registrar: Registrar) {
-      val channel = MethodChannel(registrar.messenger(), "mecab_dart")
-      channel.setMethodCallHandler(MecabDartPlugin())
-    }
+  override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+    channel = MethodChannel(flutterPluginBinding.binaryMessenger, "mecab_dart")
+    channel.setMethodCallHandler(this)
   }
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
@@ -41,5 +25,6 @@ public class MecabDartPlugin: FlutterPlugin, MethodCallHandler {
   }
 
   override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
+    channel.setMethodCallHandler(null)
   }
 }


### PR DESCRIPTION
## 🎯 背景
Flutter 3.29 以降で **Android v1 Embedding (`PluginRegistry.Registrar`) が完全削除**  
↓  
`mecab_dart` が `Unresolved reference 'Registrar'` でビルド失敗。  
Flutter 3.32 へアップグレードするため、プラグインを v2 Embedding に移行します。

---

## ✅ 変更点
| 種別 | 内容 |
|------|------|
| **削除** | `import io.flutter.plugin.common.PluginRegistry.Registrar`<br>`companion object { registerWith… }` |
| **更新** | `onAttachedToEngine` – `getFlutterEngine().getDartExecutor()` → `binding.binaryMessenger` |
| **追加** | `private lateinit var channel: MethodChannel` をクラスレベルに定義 |
| **解放** | `onDetachedFromEngine` で `channel.setMethodCallHandler(null)` |

> **Dart API 変更なし** — 既存コードはそのまま動きます。

---

## 📌 影響範囲
- **Android ネイティブ層のみ**  
- iOS / Web / Desktop への影響はありません  