### PR TITLE
feat: NDK r28対応（16KBページサイズ対応）

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
-    
+
     externalNativeBuild {
         cmake {
            path "CMakeLists.txt"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,10 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 33
 
+    // NDK r28を指定（16KBページサイズ対応のため）
+    // 参考: Google Play 16KB ページサイズ対応要件（Android 15+）
+    ndkVersion "28.0.12433566"
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }


### PR DESCRIPTION
## 概要

Google Play Storeの16KBページサイズ対応要件（2025年11月1日以降必須）に対応するため、Android NDK r28を指定するように更新しました。

**リポジトリ**: `tomonorisuzuk1/mecab_dart`

## 対応内容

### NDK r28の設定を追加

`android/build.gradle`にNDK r28を指定：

```gradle
android {
    compileSdkVersion 33

    // NDK r28を指定（16KBページサイズ対応のため）
    // 参考: Google Play 16KB ページサイズ対応要件（Android 15+）
    ndkVersion "28.0.12433566"
    
    // ...
}
```

### 確認事項

- ✅ 4KB固定リンカーフラグ（`-Wl,-z,common-page-size=4096`）は使用されていないことを確認
- ✅ CMakeLists.txtに問題なし
- ✅ NDK r28でビルド可能

## 参考資料

- [Google Play 16KBページサイズ要件](https://developer.android.com/guide/practices/page-sizes)
- [Android NDK r28 Release Notes](https://developer.android.com/ndk/downloads/revision_history)

## 関連リポジトリ

- **メインリポジトリ**: [tomonorisuzuk1/57577 PR #2086](https://github.com/tomonorisuzuk1/57577/pull/2086) - 16KB page size 対応（NDK r28/CI整備/段階検証ログ付き）

## タグ

このPRマージ後、`v0.1.7-ndk-r28`タグを発行済みです。
